### PR TITLE
Fix for issue #26. Column aliases containing spaces cause an error.

### DIFF
--- a/.github/workflows/mysql_test.yml
+++ b/.github/workflows/mysql_test.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.8, 3.9, 3.10, 3.11]
+        python-version: [3.8, 3.9, 3.10.13, 3.11]
         django-version: [3.2.21, 4.1.11, 4.2.5]
         exclude:
           - python-version: 3.8

--- a/.github/workflows/mysql_test.yml
+++ b/.github/workflows/mysql_test.yml
@@ -12,13 +12,17 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.6, 3.7, 3.8]
-        django-version: [2.2.27, 3.0.14, 4.0.2]
+        python-version: [3.8, 3.9, 3.10, 3.11]
+        django-version: [3.2.21, 4.1.11, 4.2.5]
         exclude:
-          - python-version: 3.6
-            django-version: 4.0.2
-          - python-version: 3.7
-            django-version: 4.0.2
+          - python-version: 3.8
+            django-version: 4.1.11
+          - python-version: 3.8
+            django-version: 4.2.5
+          - python-version: 3.11
+            django-version: 3.2.21
+          - python-version: 3.11
+            django-version: 4.1.11
     services:
       mysql:
         image: mysql

--- a/.github/workflows/postgres_test.yml
+++ b/.github/workflows/postgres_test.yml
@@ -12,13 +12,17 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.6, 3.7, 3.8]
-        django-version: [2.2.27, 3.0.14, 4.0.2]
+        python-version: [ 3.8, 3.9, 3.10, 3.11 ]
+        django-version: [ 3.2.21, 4.1.11, 4.2.5 ]
         exclude:
-          - python-version: 3.6
-            django-version: 4.0.2
-          - python-version: 3.7
-            django-version: 4.0.2
+          - python-version: 3.8
+            django-version: 4.1.11
+          - python-version: 3.8
+            django-version: 4.2.5
+          - python-version: 3.11
+            django-version: 3.2.21
+          - python-version: 3.11
+            django-version: 4.1.11
     services:
       postgres:
         image: postgres

--- a/.github/workflows/postgres_test.yml
+++ b/.github/workflows/postgres_test.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [ 3.8, 3.9, 3.10, 3.11 ]
+        python-version: [ 3.8, 3.9, 3.10.13, 3.11 ]
         django-version: [ 3.2.21, 4.1.11, 4.2.5 ]
         exclude:
           - python-version: 3.8

--- a/.github/workflows/sqlite_test.yml
+++ b/.github/workflows/sqlite_test.yml
@@ -12,13 +12,17 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.6, 3.7, 3.8]
-        django-version: [2.2.27, 3.0.14, 4.0.2]
+        python-version: [ 3.8, 3.9, 3.10, 3.11 ]
+        django-version: [ 3.2.21, 4.1.11, 4.2.5 ]
         exclude:
-          - python-version: 3.6
-            django-version: 4.0.2
-          - python-version: 3.7
-            django-version: 4.0.2
+          - python-version: 3.8
+            django-version: 4.1.11
+          - python-version: 3.8
+            django-version: 4.2.5
+          - python-version: 3.11
+            django-version: 3.2.21
+          - python-version: 3.11
+            django-version: 4.1.11
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/sqlite_test.yml
+++ b/.github/workflows/sqlite_test.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [ 3.8, 3.9, 3.10, 3.11 ]
+        python-version: [ 3.8, 3.9, 3.10.13, 3.11 ]
         django-version: [ 3.2.21, 4.1.11, 4.2.5 ]
         exclude:
           - python-version: 3.8

--- a/django_pivot/tests/pivot/models.py
+++ b/django_pivot/tests/pivot/models.py
@@ -4,16 +4,10 @@ from django.db import models
 class Region(models.Model):
     name = models.CharField(max_length=7)
 
-    def __unicode__(self):
-        return self.name
-
 
 class Store(models.Model):
     name = models.CharField(max_length=20)
     region = models.ForeignKey(Region, on_delete=models.CASCADE)
-
-    def __unicode__(self):
-        return self.name
 
 
 class ShirtSales(models.Model):

--- a/django_pivot/tests/pivot/test.py
+++ b/django_pivot/tests/pivot/test.py
@@ -29,9 +29,9 @@ dates = ['2004-12-24',
 store_names = [
     'ABC Shirts',
     'Shirt Emporium',
-    'Just Shirts',
-    'Shirts R Us',
-    'Shirts N More'
+    'Just Shirts;',
+    'Shirts --R Us',
+    'Shirts N "More"'
 ]
 
 
@@ -70,11 +70,11 @@ class Tests(TestCase):
 
         regions = list(Region.objects.all())
 
-        Store(name='ABC Shirts', region=regions[0]).save()
-        Store(name='Shirt Emporium', region=regions[1]).save()
-        Store(name='Just Shirts', region=regions[2]).save()
-        Store(name='Shirts R Us', region=regions[3]).save()
-        Store(name='Shirts N More', region=regions[0]).save()
+        Store(name=store_names[0], region=regions[0]).save()
+        Store(name=store_names[1], region=regions[1]).save()
+        Store(name=store_names[2], region=regions[2]).save()
+        Store(name=store_names[3], region=regions[3]).save()
+        Store(name=store_names[4], region=regions[0]).save()
 
         units = [12, 9, 10, 15, 13, 9, 15, 3, 7]
         prices = [11.04, 13.00, 11.96, 11.27, 12.12, 13.74, 11.44, 12.63, 12.06, 13.42, 11.48]


### PR DESCRIPTION
Since column aliases in annotations are now restricted to not have whitespace, sql comments, quotes, or semicolons, they are aliased during the SQL query, and returned back after the query returns.

Test data has been updated so that each of the disallowed characters is used.