### PR TITLE
Ordered querysets

### DIFF
--- a/Readme.rst
+++ b/Readme.rst
@@ -197,7 +197,7 @@ The test suite is run by `Travis <https://travis-ci.org/martsberger/django-pivot
 with Django versions 1.11, 2.0 and 2.1 and backends sqlite, MySQL, and Postgres. If you
 want to run the test suite locally, from the root directory::
 
-    python runtests.py --settings=django_pivot.tests.test_sqlite_settings
+    python runtests.py
 
 That will use sqlite as the backend and whatever version of Django you have
 in your current environment.

--- a/django_pivot/pivot.py
+++ b/django_pivot/pivot.py
@@ -23,7 +23,7 @@ def pivot(queryset, rows, column, data, aggregation=Sum, choices='auto', display
     """
     values = [rows] if isinstance(rows, str) else list(rows)
 
-    queryset = _get_queryset(queryset)
+    queryset = _get_queryset(queryset).order_by()
 
     column_values = get_column_values(queryset, column, choices)
 

--- a/django_pivot/pivot.py
+++ b/django_pivot/pivot.py
@@ -5,7 +5,8 @@ from django.shortcuts import _get_queryset
 from django_pivot.utils import get_column_values, get_field_choices, default_fill
 
 
-def pivot(queryset, rows, column, data, aggregation=Sum, choices='auto', display_transform=lambda s: s, default=None, row_range=()):
+def pivot(queryset, rows, column, data, aggregation=Sum, choices='auto', display_transform=lambda s: s,
+          default=None, row_range=(), ordering=()):
     """
     Takes a queryset and pivots it. The result is a table with one record
     per unique value in the `row` column, a column for each unique value in the `column` column
@@ -16,14 +17,16 @@ def pivot(queryset, rows, column, data, aggregation=Sum, choices='auto', display
     :param column: string, name of column that will define columns
     :param data: column name or Combinable
     :param aggregation: aggregation function to apply to data column
-    :param display_transform: function that takes a string and returns a string
+    :param choices: specify 'minimum' if you want to do an extra database query to get only choices present in the data
+    :param display_transform: function that takes an object and returns a string
     :param default: default value to pass to the aggregate function when no record is found
     :param row_range: iterable with the expected range of rows in the result
+    :param ordering: option to specify how the resulting pivot should be ordered
     :return: ValuesQueryset
     """
     values = [rows] if isinstance(rows, str) else list(rows)
 
-    queryset = _get_queryset(queryset).order_by()
+    queryset = _get_queryset(queryset).order_by(*ordering)
 
     column_values = get_column_values(queryset, column, choices)
 

--- a/django_pivot/tests/pivot/models.py
+++ b/django_pivot/tests/pivot/models.py
@@ -20,3 +20,6 @@ class ShirtSales(models.Model):
     units = models.IntegerField()
     price = models.DecimalField(max_digits=8, decimal_places=2)
     store = models.ForeignKey(Store, on_delete=models.CASCADE)
+
+    class Meta:
+        ordering = ['shipped']

--- a/django_pivot/tests/pivot/test.py
+++ b/django_pivot/tests/pivot/test.py
@@ -173,8 +173,9 @@ class Tests(TestCase):
         else:
             return
 
-        shirt_sales = ShirtSales.objects.annotate(**annotations).order_by('date_sort')
-        monthly_report = pivot(shirt_sales, 'Month', 'store__name', 'units', default=0)
+        shirt_sales = ShirtSales.objects.annotate(**annotations)
+        monthly_report = pivot(shirt_sales, 'Month', 'store__name', 'units', default=0,
+                               ordering=['date_sort'])
 
         # Get the months and assert that the order by that we sent in is respected
         months = [record['Month'] for record in monthly_report]
@@ -192,10 +193,10 @@ class Tests(TestCase):
                                                                              ss.store.name == name)))
 
     def test_annotate_non_ordered_field(self):
-        qs = ShirtSales.objects.annotate(period=Trunc('shipped', 'month'))
+        qs = ShirtSales.objects.annotate(period=Trunc('shipped', 'month')).order_by()
         result = pivot(qs, 'period', 'gender', 'style', Count)
 
-        self.assertEqual(len(result), 6)
+        self.assertEqual(len(result), 7)
 
     def test_pivot_with_default_fill(self):
         shirt_sales = ShirtSales.objects.filter(shipped__gt='2005-01-25', shipped__lt='2005-02-03')

--- a/django_pivot/tests/pivot/test.py
+++ b/django_pivot/tests/pivot/test.py
@@ -5,7 +5,8 @@ from decimal import Decimal
 from itertools import chain
 
 from django.conf import settings
-from django.db.models import CharField, Func, F, Avg, DecimalField, ExpressionWrapper
+from django.db.models import CharField, Func, F, Avg, DecimalField, ExpressionWrapper, Count
+from django.db.models.functions import Trunc
 from django.test import TestCase
 try:
     from django.utils.encoding import force_text
@@ -189,6 +190,12 @@ class Tests(TestCase):
                                                    for ss in shirt_sales if (int(ss.shipped.year) == int(year) and
                                                                              int(ss.shipped.month) == int(month) and
                                                                              ss.store.name == name)))
+
+    def test_annotate_non_ordered_field(self):
+        qs = ShirtSales.objects.annotate(period=Trunc('shipped', 'month'))
+        result = pivot(qs, 'period', 'gender', 'style', Count)
+
+        self.assertEqual(len(result), 6)
 
     def test_pivot_with_default_fill(self):
         shirt_sales = ShirtSales.objects.filter(shipped__gt='2005-01-25', shipped__lt='2005-02-03')

--- a/runtests.py
+++ b/runtests.py
@@ -5,21 +5,12 @@ from optparse import OptionParser
 
 def parse_args():
     parser = OptionParser()
-    parser.add_option('-s', '--settings', help='Define settings.')
-    parser.add_option('-t', '--unittest', help='Define which test to run. Default all.')
-    options, args = parser.parse_args()
+    parser.add_option('-s', '--settings', default='django_pivot.tests.test_sqlite_settings', help='Define settings.')
+    return parser.parse_args()
 
-    if not options.settings:
-        parser.print_help()
-        sys.exit(1)
-
-    if not options.unittest:
-        options.unittest = ['pivot']
-
-    return options
 
 if __name__ == '__main__':
-    options = parse_args()
+    options, tests = parse_args()
     os.environ['DJANGO_SETTINGS_MODULE'] = options.settings
 
     # Local imports because DJANGO_SETTINGS_MODULE needs to be set first
@@ -32,4 +23,4 @@ if __name__ == '__main__':
 
     TestRunner = get_runner(settings)
     runner = TestRunner(verbosity=1, interactive=True, failfast=False)
-    sys.exit(runner.run_tests([]))
+    sys.exit(runner.run_tests(tests))


### PR DESCRIPTION
Fixes issue #28 (part 1 of issue #5). By default ordering is removed from querysets passed to pivot. If an order is required in the resulting pivot table, there is an optional `ordering` paramter to the pivot function.